### PR TITLE
Make AWS instance size a variable

### DIFF
--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -9,6 +9,10 @@ variable "aws_region" {
   default = "us-west-2"
 }
 
+variable "aws_instance_size" {
+  default = "t3.large"
+}
+
 ////////////////////////////////
 // Tags
 

--- a/terraform/aws/workstation.tf
+++ b/terraform/aws/workstation.tf
@@ -1,7 +1,7 @@
 resource "aws_instance" "workstation" {
   count                       = "${var.count}"
   ami                         = "${data.aws_ami.windows_workstation.id}"
-  instance_type               = "t2.large"
+  instance_type               = "${var.aws_instance_size}"
   key_name                    = "${var.aws_key_pair_name}"
   subnet_id                   = "${aws_subnet.habworkshop-subnet.id}"
   vpc_security_group_ids      = ["${aws_security_group.habworkshop.id}"]


### PR DESCRIPTION
Add a bit of flexibility to instance sizes for the workstation.  Update the default instance size from `t2.large` to `t3.large`.